### PR TITLE
Improve task form validation and window rendering UI

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,6 +14,8 @@
             <p class="text-gray-600">Schedule your tasks based on weather conditions</p>
         </header>
 
+        <div id="notificationContainer" class="mb-6 space-y-3" aria-live="polite"></div>
+
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <!-- Task Form -->
             <div class="bg-white rounded-lg shadow-md p-6">
@@ -22,14 +24,17 @@
                     <div>
                         <label class="block text-sm font-medium text-gray-700">Task Name</label>
                         <input type="text" id="taskName" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                        <p id="taskNameError" class="mt-1 text-sm text-red-600 hidden"></p>
                     </div>
                     <div>
                         <label class="block text-sm font-medium text-gray-700">ZIP Code</label>
                         <input type="text" id="location" required inputmode="numeric" placeholder="e.g., 01778" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                        <p id="locationError" class="mt-1 text-sm text-red-600 hidden"></p>
                     </div>
                     <div>
                         <label class="block text-sm font-medium text-gray-700">Duration (hours)</label>
                         <input type="number" id="durationHours" required min="1" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                        <p id="durationHoursError" class="mt-1 text-sm text-red-600 hidden"></p>
                     </div>
 
                     <!-- Temperature Range Section -->
@@ -45,10 +50,12 @@
                                 <div class="flex-1">
                                     <label class="block text-sm text-gray-600">Min Temperature (&deg;F)</label>
                                     <input type="number" id="minTemp" placeholder="Min" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                                    <p id="minTempError" class="mt-1 text-sm text-red-600 hidden"></p>
                                 </div>
                                 <div class="flex-1">
                                     <label class="block text-sm text-gray-600">Max Temperature (&deg;F)</label>
                                     <input type="number" id="maxTemp" placeholder="Max" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                                    <p id="maxTempError" class="mt-1 text-sm text-red-600 hidden"></p>
                                 </div>
                             </div>
                         </div>
@@ -67,10 +74,12 @@
                                 <div class="flex-1">
                                     <label class="block text-sm text-gray-600">Min Humidity (%)</label>
                                     <input type="number" id="minHumidity" min="0" max="100" placeholder="Min" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                                    <p id="minHumidityError" class="mt-1 text-sm text-red-600 hidden"></p>
                                 </div>
                                 <div class="flex-1">
                                     <label class="block text-sm text-gray-600">Max Humidity (%)</label>
                                     <input type="number" id="maxHumidity" min="0" max="100" placeholder="Max" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                                    <p id="maxHumidityError" class="mt-1 text-sm text-red-600 hidden"></p>
                                 </div>
                             </div>
                         </div>
@@ -85,14 +94,17 @@
                     <div>
                         <label class="block text-sm font-medium text-gray-700">Earliest Start Time</label>
                         <input type="time" id="earliestStart" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                        <p id="earliestStartError" class="mt-1 text-sm text-red-600 hidden"></p>
                     </div>
                     <div>
                         <label class="block text-sm font-medium text-gray-700">Latest Start Time</label>
                         <input type="time" id="latestStart" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                        <p id="latestStartError" class="mt-1 text-sm text-red-600 hidden"></p>
                     </div>
                     <div class="flex space-x-2">
-                        <button type="submit" id="submitButton" class="flex-1 bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
-                            Add Task
+                        <button type="submit" id="submitButton" class="flex-1 inline-flex items-center justify-center bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition">
+                            <span id="submitButtonSpinner" class="hidden h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent mr-2"></span>
+                            <span id="submitButtonText">Add Task</span>
                         </button>
                         <button type="button" id="cancelEditButton" class="hidden flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2">
                             Cancel


### PR DESCRIPTION
## Summary
- add a notification container, spinner-ready submit button, and inline error placeholders to the index template
- replace alert usage with dismissible toasts, add rich client-side validation, and show a loading state while saving tasks
- render suggestion results as styled cards that highlight available windows and blockers without exposing raw strings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9ecb6e8388320ae8af964944bf182