### PR TITLE
Stop scanning forecast blocks after satisfying duration

### DIFF
--- a/app/find_windows.py
+++ b/app/find_windows.py
@@ -110,8 +110,10 @@ def find_windows(
         start_idx = i
         total_hours = 0
         j = i
-        last_dt = forecast[start_idx]['dt']
+        window_start = forecast[start_idx]['dt']
+        last_dt = window_start
         window_failed = False
+        window_emitted = False
         while j < n:
             block = forecast[j]
             if j > start_idx and block['dt'] - last_dt != block_hours * 3600:
@@ -138,10 +140,12 @@ def find_windows(
             total_hours += block_hours
             last_dt = block['dt']
             j += 1
-        if total_hours < duration_hours and j >= n:
+            if total_hours >= duration_hours:
+                window_emitted = True
+                break
+        if not window_emitted and total_hours < duration_hours and j >= n:
             failures['forecast horizon ended before reaching required duration'] += 1
-        if not window_failed and total_hours >= duration_hours:
-            window_start = forecast[start_idx]['dt']
+        if (window_emitted or (not window_failed and total_hours >= duration_hours)) and not window_failed:
             window_end = last_dt + block_hours * 3600
             actual_hours = int((window_end - window_start) / 3600)
             valid_windows.append(

--- a/tests/test_find_windows.py
+++ b/tests/test_find_windows.py
@@ -1,0 +1,78 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.find_windows import find_windows
+
+
+BASE_TS = 1_700_000_000
+BLOCK_HOURS = 3
+BLOCK_SECONDS = BLOCK_HOURS * 3600
+
+
+def make_block(index: int, **overrides):
+    block = {
+        'dt': BASE_TS + index * BLOCK_SECONDS,
+        'temp': 70.0,
+        'rain': 0.0,
+        'humidity': 50,
+    }
+    block.update(overrides)
+    return block
+
+
+def test_window_returned_when_post_duration_block_has_rain():
+    forecast = [
+        make_block(0),
+        make_block(1),
+        make_block(2, rain=1.0),
+    ]
+
+    result = find_windows(
+        forecast=forecast,
+        min_temp=None,
+        max_temp=None,
+        min_humidity=None,
+        max_humidity=None,
+        no_rain=True,
+        duration_hours=6,
+    )
+
+    assert len(result['windows']) == 1
+    window = result['windows'][0]
+    assert window['start_ts'] == forecast[0]['dt']
+    assert window['duration'] == '6h'
+    assert result['reason_summary'] is None
+    assert any(detail['reason'] == 'rain expected during window' for detail in result['reason_details'])
+
+
+def test_window_returned_when_post_duration_block_has_gap():
+    gap_block = make_block(2)
+    gap_block['dt'] = make_block(1)['dt'] + 2 * 3600
+
+    forecast = [
+        make_block(0),
+        make_block(1),
+        gap_block,
+    ]
+
+    result = find_windows(
+        forecast=forecast,
+        min_temp=None,
+        max_temp=None,
+        min_humidity=None,
+        max_humidity=None,
+        no_rain=False,
+        duration_hours=6,
+    )
+
+    assert len(result['windows']) == 1
+    window = result['windows'][0]
+    assert window['start_ts'] == forecast[0]['dt']
+    assert window['duration'] == '6h'
+    assert result['reason_summary'] is None
+    assert any(
+        detail['reason'] == 'forecast horizon ended before reaching required duration'
+        for detail in result['reason_details']
+    )


### PR DESCRIPTION
## Summary
- break out of the inner search loop once the required duration is satisfied so that later blocks cannot invalidate a successful window
- track emitted windows while recording failures for other candidates without losing already satisfied windows
- add regression tests covering windows that are immediately followed by a rainy block or a forecast gap

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9ff65a2648320bca497f19934e73b