### PR TITLE
Respect timezone offsets when evaluating task windows

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -13,7 +13,7 @@ def get_tasks(db: Session):
 def create_task(db: Session, task: schemas.TaskCreate):
     # Fetch forecast and find scheduling window
     try:
-        forecast = weather.fetch_hourly_forecast(task.location)
+        forecast, timezone_offset = weather.fetch_hourly_forecast(task.location)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     window_result = find_windows.find_windows(
@@ -25,7 +25,8 @@ def create_task(db: Session, task: schemas.TaskCreate):
         no_rain=bool(task.no_rain),
         duration_hours=task.duration_hours,
         earliest_start=getattr(task, 'earliest_start', None),
-        latest_start=getattr(task, 'latest_start', None)
+        latest_start=getattr(task, 'latest_start', None),
+        timezone_offset=timezone_offset,
     )
     windows = window_result['windows']
     scheduled_time = None
@@ -68,7 +69,7 @@ def update_task(db: Session, task_id: int, task_update: schemas.TaskCreate):
     for field, value in update_data.items():
         setattr(task, field, value)
     try:
-        forecast = weather.fetch_hourly_forecast(task.location)
+        forecast, timezone_offset = weather.fetch_hourly_forecast(task.location)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     window_result = find_windows.find_windows(
@@ -80,7 +81,8 @@ def update_task(db: Session, task_id: int, task_update: schemas.TaskCreate):
         no_rain=bool(task.no_rain),
         duration_hours=task.duration_hours,
         earliest_start=task.earliest_start,
-        latest_start=task.latest_start
+        latest_start=task.latest_start,
+        timezone_offset=timezone_offset,
     )
     windows = window_result['windows']
     task.scheduled_time = datetime.utcfromtimestamp(windows[0]['start_ts']) if windows else None

--- a/app/main.py
+++ b/app/main.py
@@ -68,7 +68,7 @@ def get_suggestions(request: schemas.SuggestionRequest, db: Session = Depends(ge
     task = crud.get_task(db, request.task_id)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
-    forecast = weather.fetch_hourly_forecast(task.location)
+    forecast, timezone_offset = weather.fetch_hourly_forecast(task.location)
     window_result = find_windows.find_windows(
         forecast=forecast,
         min_temp=task.min_temp,
@@ -78,7 +78,8 @@ def get_suggestions(request: schemas.SuggestionRequest, db: Session = Depends(ge
         no_rain=bool(task.no_rain),
         duration_hours=task.duration_hours,
         earliest_start=getattr(task, 'earliest_start', None),
-        latest_start=getattr(task, 'latest_start', None)
+        latest_start=getattr(task, 'latest_start', None),
+        timezone_offset=timezone_offset,
     )
     return {
         "possible_windows": window_result["windows"],

--- a/app/weather.py
+++ b/app/weather.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Tuple
+
 import requests
 
 OPENWEATHER_API_KEY = "28c994ffe7bf1c4f8975ec9e222e3589"
@@ -23,8 +25,11 @@ def _normalize_zip(zip_code: str) -> str:
     return f"{digits},{country}"
 
 
-def fetch_hourly_forecast(zip_code: str):
-    """Fetch the next five days of hourly weather for a ZIP code."""
+def fetch_hourly_forecast(zip_code: str) -> Tuple[List[Dict[str, float]], int]:
+    """Fetch the next five days of hourly weather for a ZIP code.
+
+    Returns a tuple of (hourly blocks, location timezone offset).
+    """
     normalized = _normalize_zip(zip_code)
     url = (
         "https://api.openweathermap.org/data/2.5/forecast?"
@@ -38,6 +43,7 @@ def fetch_hourly_forecast(zip_code: str):
     if "list" not in data:
         message = data.get("message", "Unknown error from weather API.")
         raise ValueError(f"Weather API error: {message}")
+    timezone_offset = int(data.get("city", {}).get("timezone", 0) or 0)
     results = []
     for entry in data["list"]:
         results.append(
@@ -48,4 +54,4 @@ def fetch_hourly_forecast(zip_code: str):
                 "humidity": entry["main"].get("humidity"),
             }
         )
-    return results
+    return results, timezone_offset

--- a/tests/test_timezone_handling.py
+++ b/tests/test_timezone_handling.py
@@ -1,0 +1,72 @@
+import unittest
+
+from app import find_windows
+
+
+def _forecast_block(ts: int) -> dict:
+    return {
+        "dt": ts,
+        "temp": 70.0,
+        "rain": 0,
+        "humidity": 50,
+    }
+
+
+class FindWindowsTimezoneTests(unittest.TestCase):
+    def test_earliest_constraint_applies_timezone_offset(self):
+        base_ts = 1693526400  # 2023-09-01 00:00:00 UTC
+        forecast = [
+            _forecast_block(base_ts),
+            _forecast_block(base_ts + 10800),
+        ]
+        result = find_windows.find_windows(
+            forecast=forecast,
+            min_temp=None,
+            max_temp=None,
+            min_humidity=None,
+            max_humidity=None,
+            no_rain=False,
+            duration_hours=3,
+            earliest_start="04:00",
+            latest_start=None,
+            timezone_offset=7200,  # UTC+2
+        )
+        self.assertEqual(len(result["windows"]), 1)
+        window = result["windows"][0]
+        self.assertEqual(window["start_ts"], forecast[1]["dt"])
+        self.assertEqual(window["display"], "9/1 5 AM - 8 AM")
+        self.assertIn(
+            {"reason": "start before earliest allowed (02:00)", "count": 1},
+            result["reason_details"],
+        )
+
+    def test_latest_constraint_applies_timezone_offset(self):
+        base_ts = 1693526400  # 2023-09-01 00:00:00 UTC
+        forecast = [
+            _forecast_block(base_ts),
+            _forecast_block(base_ts + 10800),
+        ]
+        result = find_windows.find_windows(
+            forecast=forecast,
+            min_temp=None,
+            max_temp=None,
+            min_humidity=None,
+            max_humidity=None,
+            no_rain=False,
+            duration_hours=3,
+            earliest_start=None,
+            latest_start="02:00",
+            timezone_offset=-10800,  # UTC-3
+        )
+        self.assertEqual(len(result["windows"]), 1)
+        window = result["windows"][0]
+        self.assertEqual(window["start_ts"], forecast[1]["dt"])
+        self.assertEqual(window["display"], "9/1 12 AM - 3 AM")
+        self.assertIn(
+            {"reason": "start after latest allowed (21:00)", "count": 1},
+            result["reason_details"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- include the OpenWeather timezone offset with fetched hourly forecasts
- apply the location offset when checking constraints and formatting suggestion windows
- update forecast consumers to pass the offset and add tests covering non-UTC earliest/latest windows

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68c9ff6467fc832090c05fffca0205d7