### PR TITLE
Use shared renderer when fetching windows manually

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1220,35 +1220,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             if (response.ok) {
                 const data = await response.json();
-                if (data.possible_windows && data.possible_windows.length > 0) {
-                    windowsDiv.innerHTML = '<b>Possible Windows:</b><br>' + data.possible_windows
-                        .map((window) => `${window.display} (${window.duration})`)
-                        .join('<br>');
-                } else {
-                    const fallbackMessage = data.no_windows_reason || 'No available windows found.';
-                    const blockersIndex = fallbackMessage.indexOf('Common blockers:');
-                    const visibleMessage = blockersIndex !== -1
-                        ? fallbackMessage.slice(0, blockersIndex).trim()
-                        : fallbackMessage;
-                    const hiddenIntro = blockersIndex !== -1
-                        ? fallbackMessage.slice(blockersIndex).trim()
-                        : '';
-
-                    if (data.reason_details && data.reason_details.length > 0) {
-                        const listItems = data.reason_details
-                            .map((detail) => `<li>${detail.reason} (${detail.count})</li>`)
-                            .join('');
-                        const introHtml = hiddenIntro ? `<p>${hiddenIntro}</p>` : '';
-                        const detailsBlock = `<div class="mt-1">${introHtml}<ul class="list-disc pl-5">${listItems}</ul></div>`;
-                        windowsDiv.innerHTML = `<div>${visibleMessage}</div>` +
-                            `<details class="mt-1 text-sm">` +
-                            `<summary class="cursor-pointer text-blue-600">Show details</summary>` +
-                            detailsBlock +
-                            `</details>`;
-                    } else {
-                        windowsDiv.textContent = fallbackMessage;
-                    }
-                }
+                renderWindowsResults(windowsDiv, data);
             } else {
                 renderWindowsError(windowsDiv, 'Unable to fetch windows at this time.');
                 showNotification('error', 'Unable to fetch windows for this task.');


### PR DESCRIPTION
## Summary
- reuse renderWindowsResults when loading windows for a task from the suggestions endpoint
- keep error handling consistent by delegating to renderWindowsError when the request fails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca068a09b0832090b7cf15c37cb758