### PR TITLE
Add asset debug logging and time field clearing controls

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -11,6 +11,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const temperatureInputs = document.getElementById('temperatureInputs');
     const humidityInputs = document.getElementById('humidityInputs');
     const notificationContainer = document.getElementById('notificationContainer');
+    const earliestStartInput = document.getElementById('earliestStart');
+    const latestStartInput = document.getElementById('latestStart');
+    const clearTimeButton = document.getElementById('clearTimeButton');
     const notificationStyles = {
         success: 'bg-green-50 border border-green-200 text-green-900',
         error: 'bg-red-50 border border-red-200 text-red-900',
@@ -221,6 +224,19 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
+    const updateClearTimeButtonState = () => {
+        if (!clearTimeButton) {
+            return;
+        }
+        const hasEarliest = Boolean(earliestStartInput && earliestStartInput.value);
+        const hasLatest = Boolean(latestStartInput && latestStartInput.value);
+        const hasAnyValue = hasEarliest || hasLatest;
+        clearTimeButton.disabled = !hasAnyValue;
+        clearTimeButton.classList.toggle('opacity-50', !hasAnyValue);
+        clearTimeButton.classList.toggle('cursor-not-allowed', !hasAnyValue);
+        clearTimeButton.setAttribute('aria-disabled', (!hasAnyValue).toString());
+    };
+
     const isValidZipInput = (value) => {
         if (typeof value !== 'string') {
             return false;
@@ -407,6 +423,34 @@ document.addEventListener('DOMContentLoaded', () => {
             clearSpecificFieldError('maxHumidity');
         }
     });
+
+    if (earliestStartInput) {
+        earliestStartInput.addEventListener('input', updateClearTimeButtonState);
+    }
+    if (latestStartInput) {
+        latestStartInput.addEventListener('input', updateClearTimeButtonState);
+    }
+    if (clearTimeButton) {
+        updateClearTimeButtonState();
+        clearTimeButton.addEventListener('click', (event) => {
+            event.preventDefault();
+            if (clearTimeButton.disabled) {
+                return;
+            }
+            if (earliestStartInput) {
+                earliestStartInput.value = '';
+                clearSpecificFieldError('earliestStart');
+            }
+            if (latestStartInput) {
+                latestStartInput.value = '';
+                clearSpecificFieldError('latestStart');
+            }
+            updateClearTimeButtonState();
+            if (earliestStartInput && typeof earliestStartInput.focus === 'function') {
+                earliestStartInput.focus();
+            }
+        });
+    }
 
     const buildTemperatureDisplay = (task) => {
         const hasMin = task.min_temp !== undefined && task.min_temp !== null;
@@ -956,6 +1000,7 @@ document.addEventListener('DOMContentLoaded', () => {
         cancelEditButton.classList.add('hidden');
         setLoadingState(false);
         resetToggleGroups();
+        updateClearTimeButtonState();
     };
 
     const enterEditMode = (task) => {
@@ -983,6 +1028,7 @@ document.addEventListener('DOMContentLoaded', () => {
         toggleGroupState(useHumidity, humidityInputs);
         document.getElementById('minHumidity').value = task.min_humidity ?? '';
         document.getElementById('maxHumidity').value = task.max_humidity ?? '';
+        updateClearTimeButtonState();
     };
 
     cancelEditButton.addEventListener('click', () => {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -102,6 +102,16 @@
                         <input type="time" id="latestStart" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
                         <p id="latestStartError" class="mt-1 text-sm text-red-600 hidden"></p>
                     </div>
+                    <div class="flex justify-end">
+                        <button
+                            type="button"
+                            id="clearTimeButton"
+                            class="text-sm text-blue-600 hover:text-blue-800 focus:outline-none focus:underline"
+                            title="Clear the earliest and latest start time fields"
+                        >
+                            Clear times
+                        </button>
+                    </div>
                     <div class="flex space-x-2">
                         <button type="submit" id="submitButton" class="flex-1 inline-flex items-center justify-center bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition">
                             <span id="submitButtonSpinner" class="hidden h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent mr-2"></span>
@@ -124,6 +134,33 @@
         </div>
     </div>
 
+    <script>
+        (function logAssetDebugInfo() {
+            const debugPayload = {{ asset_debug | tojson }};
+            if (!debugPayload || typeof window === 'undefined' || !window.console) {
+                return;
+            }
+            const { serverTime, assets } = debugPayload;
+            const labelledAssets = Object.values(assets || {});
+            console.info('[Weather Task Scheduler] Server asset snapshot', {
+                serverTime,
+                assets: labelledAssets,
+            });
+            if (labelledAssets.length > 0) {
+                const freshnessSummary = labelledAssets
+                    .map((asset) => {
+                        const label = asset?.label || asset?.path || 'unknown asset';
+                        const updated = asset?.lastModified || 'unknown time';
+                        const ageSeconds = typeof asset?.ageSeconds === 'number'
+                            ? `${asset.ageSeconds}s old`
+                            : 'age unknown';
+                        return `${label}: ${updated} (${ageSeconds})`;
+                    })
+                    .join(', ');
+                console.info('[Weather Task Scheduler] Asset freshness -> %s', freshnessSummary);
+            }
+        })();
+    </script>
     <script src="/static/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- provide asset freshness metadata from the FastAPI backend and expose it in the HTML template for console debugging
- log server asset timestamps in the browser console to show how up to date bundled files are
- add a Clear times control that resets the earliest and latest start fields and keeps the UI state in sync

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cada6eff708320b409516110c1e0e8