### PR TITLE
Clarify weather filter labels and remove clear times button

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -13,7 +13,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const notificationContainer = document.getElementById('notificationContainer');
     const earliestStartInput = document.getElementById('earliestStart');
     const latestStartInput = document.getElementById('latestStart');
-    const clearTimeButton = document.getElementById('clearTimeButton');
     const notificationStyles = {
         success: 'bg-green-50 border border-green-200 text-green-900',
         error: 'bg-red-50 border border-red-200 text-red-900',
@@ -193,20 +192,6 @@ document.addEventListener('DOMContentLoaded', () => {
             clearSpecificFieldError(fieldId);
         });
     };
-
-    const updateClearTimeButtonState = () => {
-        if (!clearTimeButton) {
-            return;
-        }
-        const hasEarliest = Boolean(earliestStartInput && earliestStartInput.value);
-        const hasLatest = Boolean(latestStartInput && latestStartInput.value);
-        const hasAnyValue = hasEarliest || hasLatest;
-        clearTimeButton.disabled = !hasAnyValue;
-        clearTimeButton.classList.toggle('opacity-50', !hasAnyValue);
-        clearTimeButton.classList.toggle('cursor-not-allowed', !hasAnyValue);
-        clearTimeButton.setAttribute('aria-disabled', (!hasAnyValue).toString());
-    };
-
 
     function buildTimeOptions(intervalMinutes = 30) {
         const options = [];
@@ -595,7 +580,6 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
         earliestStartInput.addEventListener('input', () => {
-            updateClearTimeButtonState();
             syncDropdownSelection('earliestStart');
         });
     }
@@ -612,36 +596,11 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
         latestStartInput.addEventListener('input', () => {
-            updateClearTimeButtonState();
             syncDropdownSelection('latestStart');
         });
     }
-    if (clearTimeButton) {
-        updateClearTimeButtonState();
-        syncAllDropdownSelections();
-        clearTimeButton.addEventListener('click', (event) => {
-            event.preventDefault();
-            if (clearTimeButton.disabled) {
-                return;
-            }
-            if (earliestStartInput) {
-                earliestStartInput.value = '';
-                earliestStartInput.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-            clearSpecificFieldError('earliestStart');
-            if (latestStartInput) {
-                latestStartInput.value = '';
-                latestStartInput.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-            clearSpecificFieldError('latestStart');
-            updateClearTimeButtonState();
-            syncAllDropdownSelections();
-            closeActiveTimePicker();
-            if (earliestStartInput && typeof earliestStartInput.focus === 'function') {
-                earliestStartInput.focus();
-            }
-        });
-    }
+
+    syncAllDropdownSelections();
 
     const buildTemperatureDisplay = (task) => {
         const hasMin = task.min_temp !== undefined && task.min_temp !== null;
@@ -1191,7 +1150,6 @@ document.addEventListener('DOMContentLoaded', () => {
         cancelEditButton.classList.add('hidden');
         setLoadingState(false);
         resetToggleGroups();
-        updateClearTimeButtonState();
         syncAllDropdownSelections();
         closeActiveTimePicker();
     };
@@ -1221,7 +1179,6 @@ document.addEventListener('DOMContentLoaded', () => {
         toggleGroupState(useHumidity, humidityInputs);
         document.getElementById('minHumidity').value = task.min_humidity ?? '';
         document.getElementById('maxHumidity').value = task.max_humidity ?? '';
-        updateClearTimeButtonState();
         syncAllDropdownSelections();
         closeActiveTimePicker();
     };
@@ -1277,7 +1234,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         Duration: ${task.duration_hours} hours<br>
                         ${buildTemperatureDisplay(task)}
                         ${buildHumidityDisplay(task)}
-                        No Rain Required: ${task.no_rain ? 'Yes' : 'No'}<br>
+                        Rain-free conditions required: ${task.no_rain ? 'Yes' : 'No'}<br>
                         Scheduled Time: ${scheduledTimeDisplay}<br>
                         Created: ${createdAt}
                     </p>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -43,7 +43,7 @@
                         <div class="flex items-center mb-2">
                             <input type="checkbox" id="useTemperature" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
                             <label for="useTemperature" class="ml-2 block text-sm font-medium text-gray-700">
-                                Use Temperature Range
+                                Filter by temperature range
                             </label>
                         </div>
                         <div id="temperatureInputs" class="space-y-2 opacity-50 pointer-events-none">
@@ -67,7 +67,7 @@
                         <div class="flex items-center mb-2">
                             <input type="checkbox" id="useHumidity" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
                             <label for="useHumidity" class="ml-2 block text-sm font-medium text-gray-700">
-                                Use Humidity Range
+                                Filter by humidity range
                             </label>
                         </div>
                         <div id="humidityInputs" class="space-y-2 opacity-50 pointer-events-none">
@@ -89,7 +89,7 @@
                     <div class="flex items-center">
                         <input type="checkbox" id="noRain" checked class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
                         <label for="noRain" class="ml-2 block text-sm text-gray-700">
-                            No rain required
+                            Require rain-free conditions
                         </label>
                     </div>
                     <div>
@@ -153,16 +153,6 @@
                             </div>
                         </div>
                         <p id="latestStartError" class="mt-1 text-sm text-red-600 hidden"></p>
-                    </div>
-                    <div class="flex justify-end">
-                        <button
-                            type="button"
-                            id="clearTimeButton"
-                            class="text-sm text-blue-600 hover:text-blue-800 focus:outline-none focus:underline"
-                            title="Clear the earliest and latest start time fields"
-                        >
-                            Clear times
-                        </button>
                     </div>
                     <div class="flex space-x-2">
                         <button type="submit" id="submitButton" class="flex-1 inline-flex items-center justify-center bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition">


### PR DESCRIPTION
## Summary
- update task form labels to clarify temperature, humidity, and rain requirements
- remove the unused "Clear times" button and related JavaScript handling
- adjust task list summary text to match the new rain requirement wording

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf3022f9c8320aa0ccdf8e3fae572