### PR TITLE
Guard Puma restart plugin on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@ export OPENWEATHER_API_KEY="your-openweather-api-key"
 bin/rails server
 ```
 
-The HTML landing page at `/` highlights the JSON endpoints. Interact with the API
-using a tool such as `curl`, `HTTPie`, or Postman.
+> **Windows note:** Puma's hot-restart hook is disabled on Windows because the
+> platform cannot re-execute the `bin/rails` stub. Restart the server manually
+> after code changes.
+
+The HTML landing page at `/` highlights the JSON endpoints. Interact with the
+API using a tool such as `curl`, `HTTPie`, or Postman.
 
 ## API overview
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,4 +32,5 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
-plugin :tmp_restart
+# Windows cannot re-exec the Ruby stub, so skip hot restarts there.
+plugin :tmp_restart unless Gem.win_platform?


### PR DESCRIPTION
## Summary
- skip Puma's `tmp_restart` plugin on Windows to prevent missing `bin/rails` restarts
- document the Windows manual-restart requirement in the README

## Testing
- bundle exec rails test


------
https://chatgpt.com/codex/tasks/task_e_68cb6b6055a88320986a27d5a2be1441