### PR TITLE
Improve modal cleanup across breakpoints

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link_directory ../javascripts .js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,1156 @@
+(() => {
+  const STORAGE_KEYS = {
+    tasks: "weatherTaskScheduler.tasks",
+    lastZip: "weatherTaskScheduler.lastZip",
+    advancedOpen: "weatherTaskScheduler.advancedOpen"
+  };
+
+  const GEO_FALLBACKS = [
+    { lat: 40.7128, lon: -74.006, zip: "10001" },
+    { lat: 34.0522, lon: -118.2437, zip: "90012" },
+    { lat: 41.8781, lon: -87.6298, zip: "60604" },
+    { lat: 29.7604, lon: -95.3698, zip: "77002" },
+    { lat: 47.6062, lon: -122.3321, zip: "98101" },
+    { lat: 37.7749, lon: -122.4194, zip: "94103" }
+  ];
+
+  const analytics = (event, payload = {}) => {
+    const store = (window.analyticsEvents = window.analyticsEvents || []);
+    store.push({ event, payload, timestamp: new Date().toISOString() });
+  };
+
+  const escapeHtml = (value) => {
+    if (value == null) return "";
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  };
+
+  const dateFormatter = new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric"
+  });
+
+  const timeFormatter = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit"
+  });
+
+  const durationFormatter = (hours) => {
+    const totalMinutes = Math.round(Number(hours || 0) * 60);
+    const wholeHours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (wholeHours && minutes) {
+      return `${wholeHours} hr ${minutes} min`;
+    }
+    if (wholeHours) {
+      return wholeHours === 1 ? "1 hour" : `${wholeHours} hours`;
+    }
+    return `${minutes} min`;
+  };
+
+  const formatRange = (startIso, endIso) => {
+    const start = new Date(startIso);
+    const end = new Date(endIso);
+    const dateLabel = dateFormatter.format(start);
+    const startTime = timeFormatter.format(start);
+    const endTime = timeFormatter.format(end);
+    return `${dateLabel} · ${startTime} – ${endTime}`;
+  };
+
+  const parseTimeToMinutes = (value) => {
+    if (!value) return null;
+    const [hours, minutes] = value.split(":").map(Number);
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
+    return hours * 60 + minutes;
+  };
+
+  const clamp = (value, min, max) => {
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) return min;
+    return Math.min(Math.max(numeric, min), max);
+  };
+
+  const nearestZip = (lat, lon) => {
+    let best = null;
+    let bestDistance = Infinity;
+    GEO_FALLBACKS.forEach((candidate) => {
+      const dLat = lat - candidate.lat;
+      const dLon = lon - candidate.lon;
+      const distance = Math.sqrt(dLat * dLat + dLon * dLon);
+      if (distance < bestDistance) {
+        best = candidate;
+        bestDistance = distance;
+      }
+    });
+    return best ? best.zip : null;
+  };
+
+  const randomBetween = (min, max) => Math.round(Math.random() * (max - min) + min);
+
+  const generateWindowsForTask = (task) => {
+    const windows = [];
+    const now = new Date();
+    const durationMinutes = Math.round(task.durationHours * 60);
+    const earliest = parseTimeToMinutes(task.earliestStart) ?? 6 * 60;
+    const latestCap = parseTimeToMinutes(task.latestStart);
+    const latest = latestCap != null ? latestCap : 19 * 60;
+    const usableLatest = latest - durationMinutes;
+    if (usableLatest <= earliest) {
+      return windows;
+    }
+
+    let dayOffset = 1;
+    while (windows.length < 4 && dayOffset <= 12) {
+      const startOfDay = new Date(now);
+      startOfDay.setHours(0, 0, 0, 0);
+      startOfDay.setDate(startOfDay.getDate() + dayOffset);
+      const startMinutes = randomBetween(earliest, usableLatest);
+      const startDate = new Date(startOfDay.getTime() + startMinutes * 60000);
+      const endDate = new Date(startDate.getTime() + durationMinutes * 60000);
+
+      const temperature = task.temperatureEnabled
+        ? randomBetween(task.minTemp, task.maxTemp)
+        : randomBetween(55, 85);
+      const humidity = task.humidityEnabled
+        ? randomBetween(task.minHumidity, task.maxHumidity)
+        : randomBetween(25, 75);
+
+      const conditionsPool = task.requireDry
+        ? ["clear", "partly cloudy"]
+        : ["clear", "partly cloudy", "light rain", "overcast"];
+      const condition = conditionsPool[randomBetween(0, conditionsPool.length - 1)];
+      if (task.requireDry && condition.includes("rain")) {
+        dayOffset += 1;
+        continue;
+      }
+
+      const summary = `${temperature} °F, ${condition}`;
+      windows.push({
+        id: `${task.id}-window-${dayOffset}-${startMinutes}`,
+        start: startDate.toISOString(),
+        end: endDate.toISOString(),
+        temperature,
+        humidity,
+        condition,
+        summary
+      });
+      dayOffset += randomBetween(1, 2);
+    }
+    return windows;
+  };
+  const createSampleTasks = () => {
+    const baseTasks = [
+      {
+        id: "sample-1",
+        name: "Stain the deck",
+        durationHours: 3,
+        location: "98101",
+        earliestStart: "09:00",
+        latestStart: "17:00",
+        temperatureEnabled: true,
+        minTemp: 60,
+        maxTemp: 80,
+        humidityEnabled: true,
+        minHumidity: 20,
+        maxHumidity: 65,
+        requireDry: true,
+        status: "Scheduled",
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
+        windowsCollapsed: false
+      },
+      {
+        id: "sample-2",
+        name: "Install outdoor lights",
+        durationHours: 1.5,
+        location: "10001",
+        earliestStart: "07:00",
+        latestStart: "20:00",
+        temperatureEnabled: true,
+        minTemp: 50,
+        maxTemp: 75,
+        humidityEnabled: false,
+        minHumidity: null,
+        maxHumidity: null,
+        requireDry: false,
+        status: "Pending",
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2).toISOString(),
+        windowsCollapsed: false
+      }
+    ];
+
+    return baseTasks.map((task) => {
+      const windows = generateWindowsForTask(task);
+      let scheduledWindow = null;
+      if (windows.length) {
+        scheduledWindow = { start: windows[0].start, end: windows[0].end };
+      }
+      return {
+        ...task,
+        windows,
+        scheduledWindow
+      };
+    });
+  };
+
+  const overlap = (aStart, aEnd, bStart, bEnd) => {
+    return aStart < bEnd && bStart < aEnd;
+  };
+
+  const computeConflictFlags = (tasks) => {
+    const scheduledTasks = tasks.filter(
+      (t) => t.scheduledWindow && t.status !== "Completed"
+    );
+    const conflictMap = new Map();
+    tasks.forEach((task) => {
+      if (!task.windows) return;
+      const windows = task.windows.map((window) => {
+        const start = new Date(window.start).getTime();
+        const end = new Date(window.end).getTime();
+        const isConflict = scheduledTasks.some((other) => {
+          if (other.id === task.id || !other.scheduledWindow) return false;
+          const otherStart = new Date(other.scheduledWindow.start).getTime();
+          const otherEnd = new Date(other.scheduledWindow.end).getTime();
+          return overlap(start, end, otherStart, otherEnd);
+        });
+        const isPreferred =
+          task.scheduledWindow &&
+          task.scheduledWindow.start === window.start &&
+          task.scheduledWindow.end === window.end;
+        return { ...window, conflict: isConflict, preferred: isPreferred };
+      });
+      conflictMap.set(task.id, windows);
+    });
+    return conflictMap;
+  };
+
+  const windowConditionIcon = (window) => {
+    if (window.conflict) {
+      return '<span class="window-icons" title="Overlaps another scheduled task" data-status="conflict"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 4a1 1 0 0 0-.993.883L11 7v5a1 1 0 0 0 1.993.117L13 12V7a1 1 0 0 0-1-1Zm0 10a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"></path></svg></span>';
+    }
+    return '<span class="window-icons" data-status="clear" title="No conflicts"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M10.293 15.293 7.05 12.05a1 1 0 0 1 1.414-1.414L11 13.172l4.536-4.535a1 1 0 0 1 1.498 1.32l-.083.094-5.243 5.243a1 1 0 0 1-1.415 0Z"></path></svg></span>';
+  };
+  document.addEventListener("DOMContentLoaded", () => {
+    const shell = document.querySelector("[data-app-shell]");
+    if (!shell) return;
+
+    const elements = {
+      addPanel: document.getElementById("addTaskPanel"),
+      taskListPanel: document.getElementById("taskListPanel"),
+      taskList: document.getElementById("taskList"),
+      taskListEmpty: document.getElementById("taskListEmpty"),
+      refreshAllButton: document.getElementById("refreshAllButton"),
+      floatingButton: document.getElementById("floatingAddButton"),
+      modalOverlay: document.getElementById("modalOverlay"),
+      tabletToggle: document.getElementById("tabletToggleButton"),
+      modalCloseButton: document.getElementById("modalCloseButton"),
+      toastRegion: document.getElementById("toastRegion"),
+      form: document.getElementById("addTaskForm"),
+      submitButton: document.getElementById("submitTaskButton"),
+      cancelEditButton: document.getElementById("cancelEditButton"),
+      advancedToggle: document.getElementById("advancedToggle"),
+      advancedContent: document.getElementById("advancedContent"),
+      temperatureToggle: document.getElementById("temperatureToggle"),
+      humidityToggle: document.getElementById("humidityToggle"),
+      tempMinInput: document.getElementById("tempMin"),
+      tempMaxInput: document.getElementById("tempMax"),
+      tempMinSlider: document.getElementById("tempMinSlider"),
+      tempMaxSlider: document.getElementById("tempMaxSlider"),
+      humidityMinInput: document.getElementById("humidityMin"),
+      humidityMaxInput: document.getElementById("humidityMax"),
+      humidityMinSlider: document.getElementById("humidityMinSlider"),
+      humidityMaxSlider: document.getElementById("humidityMaxSlider"),
+      noRainToggle: document.getElementById("taskNoRain"),
+      presetChips: shell.querySelectorAll(".chip"),
+      nameInput: document.getElementById("taskName"),
+      durationInput: document.getElementById("taskDuration"),
+      durationSteppers: shell.querySelectorAll(".stepper"),
+      zipInput: document.getElementById("taskZip"),
+      earliestInput: document.getElementById("taskEarliest"),
+      latestInput: document.getElementById("taskLatest"),
+      formErrors: {
+        name: document.getElementById("nameError"),
+        duration: document.getElementById("durationError"),
+        zip: document.getElementById("zipError"),
+        time: document.getElementById("timeError"),
+        temperature: document.getElementById("temperatureError"),
+        humidity: document.getElementById("humidityError")
+      }
+    };
+
+    const state = {
+      tasks: [],
+      conflictMap: new Map(),
+      layoutMode: null,
+      addCollapsed: false,
+      modalOpen: false,
+      editingTaskId: null,
+      lastZip: localStorage.getItem(STORAGE_KEYS.lastZip) || "",
+      advancedOpen: sessionStorage.getItem(STORAGE_KEYS.advancedOpen) === "true",
+      formOrigin: null,
+      trapHandler: null,
+      previousFocus: null,
+      noWindowLogged: new Set()
+    };
+
+    const saveTasks = () => {
+      localStorage.setItem(STORAGE_KEYS.tasks, JSON.stringify(state.tasks));
+    };
+
+    const showToast = (message, type = "success") => {
+      if (!elements.toastRegion) return;
+      const toast = document.createElement("div");
+      toast.className = "toast";
+      toast.dataset.type = type;
+      toast.textContent = message;
+      elements.toastRegion.appendChild(toast);
+      setTimeout(() => {
+        toast.classList.add("leaving");
+        toast.remove();
+      }, 3500);
+    };
+
+    const persistAdvancedState = () => {
+      sessionStorage.setItem(STORAGE_KEYS.advancedOpen, String(state.advancedOpen));
+    };
+
+    const updateAdvancedVisibility = () => {
+      if (!elements.advancedContent) return;
+      if (state.advancedOpen) {
+        elements.advancedContent.hidden = false;
+        elements.advancedToggle.setAttribute("aria-expanded", "true");
+        elements.advancedToggle.querySelector(".advanced-toggle-label").textContent = "Hide advanced";
+      } else {
+        elements.advancedContent.hidden = true;
+        elements.advancedToggle.setAttribute("aria-expanded", "false");
+        elements.advancedToggle.querySelector(".advanced-toggle-label").textContent = "Show advanced";
+      }
+    };
+
+    const enableRange = (toggle, inputs, sliders, defaults) => {
+      const isChecked = toggle.checked;
+      inputs.forEach((input, index) => {
+        input.disabled = !isChecked;
+        if (isChecked && (input.value === "" || input.value == null)) {
+          input.value = defaults[index];
+        }
+      });
+      sliders.forEach((slider, index) => {
+        slider.disabled = !isChecked;
+        if (isChecked && (slider.value === "" || slider.value == null)) {
+          slider.value = defaults[index];
+        }
+      });
+    };
+
+    const syncSliders = (minInput, maxInput, minSlider, maxSlider, minBound, maxBound) => {
+      const minVal = clamp(Number(minInput.value), minBound, maxBound);
+      const maxVal = clamp(Number(maxInput.value), minBound, maxBound);
+      if (minVal > maxVal) {
+        minInput.value = maxVal;
+      }
+      minSlider.value = minInput.value;
+      maxSlider.value = maxInput.value;
+    };
+
+    const loadStoredTasks = () => {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEYS.tasks);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            state.tasks = parsed;
+            return;
+          }
+        }
+      } catch (error) {
+        console.error("Failed to parse stored tasks", error);
+      }
+      state.tasks = createSampleTasks();
+    };
+
+    const refreshConflictMap = () => {
+      state.conflictMap = computeConflictFlags(state.tasks);
+    };
+
+    const formatBadges = (task) => {
+      const badges = [];
+      if (task.requireDry) badges.push("Dry Only");
+      if (task.temperatureEnabled) badges.push(`${task.minTemp}–${task.maxTemp} °F`);
+      if (task.humidityEnabled) badges.push(`${task.minHumidity}–${task.maxHumidity} %`);
+      if (task.earliestStart && task.latestStart) {
+        badges.push(`Start ${task.earliestStart} – ${task.latestStart}`);
+      } else if (task.earliestStart) {
+        badges.push(`Start after ${task.earliestStart}`);
+      } else if (task.latestStart) {
+        badges.push(`Start before ${task.latestStart}`);
+      }
+      return badges
+        .map((badge) => `<span class="badge">${escapeHtml(badge)}</span>`)
+        .join("");
+    };
+
+    const renderTaskList = () => {
+      refreshConflictMap();
+      const { taskList, taskListEmpty } = elements;
+      taskList.innerHTML = "";
+      if (!state.tasks.length) {
+        taskListEmpty.hidden = false;
+        return;
+      }
+      taskListEmpty.hidden = true;
+      const fragment = document.createDocumentFragment();
+      const sorted = [...state.tasks].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+      sorted.forEach((task) => {
+        const card = document.createElement("article");
+        card.className = "task-card";
+        card.dataset.taskId = task.id;
+        const statusLabel = task.status || (task.scheduledWindow ? "Scheduled" : "Pending");
+        const statusKey = statusLabel.toLowerCase();
+        const metaParts = [];
+        metaParts.push(
+          `<span class="meta-item"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 5a7 7 0 1 1 0 14 7 7 0 0 1 0-14Zm0-2a9 9 0 1 0 0 18 9 9 0 0 0 0-18Zm0 4a1 1 0 0 1 1 1v3h2a1 1 0 0 1 0 2h-3a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1Z"></path></svg>${durationFormatter(task.durationHours)}</span>`
+        );
+        if (task.scheduledWindow) {
+          metaParts.push(
+            `<span class="meta-item"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 2a1 1 0 0 1 1 1v1h8V3a1 1 0 0 1 2 0v1h1a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h1V3a1 1 0 0 1 1-1ZM5 8a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1H5Zm3 3h2v2H8v-2Z"></path></svg>${formatRange(task.scheduledWindow.start, task.scheduledWindow.end)}</span>`
+          );
+        } else {
+          metaParts.push(
+            '<span class="meta-item"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 2a7 7 0 0 1 7 7v3.59l1.7 1.7a1 1 0 0 1-1.32 1.497l-.094-.083L17 13.414V9a5 5 0 0 0-9.995-.217L7 9v4.414l-2.293 2.29a1 1 0 0 1-1.497-1.32l.083-.094L5 12.59V9a7 7 0 0 1 7-7Zm0 18a2 2 0 0 1 2 2H10a2 2 0 0 1 2-2Z"></path></svg>Awaiting schedule</span>'
+          );
+        }
+
+        const conflictWindows = state.conflictMap.get(task.id) || [];
+        const possibleContent = conflictWindows.length
+          ? conflictWindows
+              .map((window, index) => {
+                const rowAttributes = [`data-window-index="${index}"`];
+                if (window.conflict) rowAttributes.push('data-conflict="true"');
+                if (window.preferred) rowAttributes.push('data-preferred="true"');
+                return `<div class="window-row" ${rowAttributes.join(" ")}>
+                  <div class="window-meta">
+                    <span>${escapeHtml(formatRange(window.start, window.end))}</span>
+                    <span>${escapeHtml(window.summary)}</span>
+                  </div>
+                  <div class="row-actions">
+                    ${windowConditionIcon(window)}
+                    <button type="button" class="text-button" data-action="schedule-window" data-window-index="${index}" aria-label="Schedule this window">Schedule this</button>
+                  </div>
+                </div>`;
+              })
+              .join("")
+          : `<div class="task-card__empty">
+                <p>No available windows in the next 10 days.</p>
+                <div class="suggestion-buttons">
+                  <button type="button" class="suggestion-button" data-action="apply-suggestion" data-suggestion="widen-temp">Widen temperature range</button>
+                  <button type="button" class="suggestion-button" data-action="apply-suggestion" data-suggestion="allow-rain">Allow non-dry</button>
+                </div>
+              </div>`;
+
+        if (!conflictWindows.length) {
+          if (!state.noWindowLogged.has(task.id)) {
+            analytics("no_windows_found", { taskId: task.id });
+            state.noWindowLogged.add(task.id);
+          }
+        } else {
+          state.noWindowLogged.delete(task.id);
+        }
+
+        const windowsCollapsed = task.windowsCollapsed ? "hidden" : "";
+        card.innerHTML = `
+          <div class="task-card__header">
+            <div>
+              <h3 class="task-card__title">${escapeHtml(task.name)}</h3>
+              <span class="status-pill" data-status="${escapeHtml(statusKey)}">${escapeHtml(statusLabel)}</span>
+            </div>
+            <div class="task-card__actions">
+              <button type="button" class="text-button" data-action="refresh-task">Refresh windows</button>
+              <button type="button" class="text-button" data-action="edit-task">Edit</button>
+              <button type="button" class="text-button" data-action="delete-task">Delete</button>
+              <button type="button" class="text-button" data-action="toggle-complete">${task.status === "Completed" ? "Reopen" : "Mark Complete"}</button>
+            </div>
+          </div>
+          <div class="task-card__meta">${metaParts.join("")}</div>
+          <div class="badge-row">${formatBadges(task)}</div>
+          <div class="possible-windows">
+            <header>
+              <h4>Possible Windows</h4>
+              <button type="button" class="text-button" data-action="toggle-windows" aria-expanded="${!task.windowsCollapsed}">${task.windowsCollapsed ? "Show" : "Hide"} windows</button>
+            </header>
+            <div class="window-list" ${windowsCollapsed}>${possibleContent}</div>
+          </div>
+        `;
+        fragment.appendChild(card);
+      });
+      taskList.appendChild(fragment);
+    };
+    const updateSubmitState = (errors) => {
+      const hasBlocking = Object.values(errors).some((value) => value);
+      elements.submitButton.disabled = hasBlocking;
+    };
+
+    const setFieldError = (field, message) => {
+      const container = elements.formErrors[field];
+      if (!container) return;
+      container.textContent = message || "";
+    };
+
+    const validateValues = (values) => {
+      const errors = {
+        name: "",
+        duration: "",
+        zip: "",
+        time: "",
+        temperature: "",
+        humidity: ""
+      };
+      const trimmedName = values.name.trim();
+      if (!trimmedName || trimmedName.length < 2 || trimmedName.length > 80) {
+        errors.name = "Task Name must be 2–80 characters.";
+      }
+
+      if (Number.isNaN(values.duration) || values.duration < 0.25 || values.duration > 24) {
+        errors.duration = "Duration must be between 0.25 and 24 hours.";
+      }
+
+      if (!/^\d{5}$/.test(values.zip)) {
+        errors.zip = "Enter a 5-digit ZIP.";
+      }
+
+      if (values.earliest && values.latest) {
+        const earliest = parseTimeToMinutes(values.earliest);
+        const latest = parseTimeToMinutes(values.latest);
+        if (earliest >= latest) {
+          errors.time = "Set Earliest before Latest.";
+        }
+      }
+
+      if (values.temperatureEnabled) {
+        if (values.minTemp > values.maxTemp) {
+          errors.temperature = "Temperature min must be less than max.";
+        }
+      }
+
+      if (values.humidityEnabled) {
+        if (values.minHumidity > values.maxHumidity) {
+          errors.humidity = "Humidity min must be less than max.";
+        }
+      }
+
+      return errors;
+    };
+
+    const displayErrors = (errors) => {
+      Object.entries(errors).forEach(([field, message]) => {
+        setFieldError(field, message);
+      });
+      updateSubmitState(errors);
+    };
+
+    const collectFormValues = () => {
+      return {
+        name: elements.nameInput.value || "",
+        duration: Number.parseFloat(elements.durationInput.value),
+        zip: elements.zipInput.value.trim(),
+        earliest: elements.earliestInput.value || "",
+        latest: elements.latestInput.value || "",
+        temperatureEnabled: elements.temperatureToggle.checked,
+        minTemp: Number(elements.tempMinInput.value || "0"),
+        maxTemp: Number(elements.tempMaxInput.value || "0"),
+        humidityEnabled: elements.humidityToggle.checked,
+        minHumidity: Number(elements.humidityMinInput.value || "0"),
+        maxHumidity: Number(elements.humidityMaxInput.value || "0"),
+        requireDry: elements.noRainToggle.checked
+      };
+    };
+
+    const resetForm = () => {
+      state.editingTaskId = null;
+      elements.form.reset();
+      elements.durationInput.value = "1";
+      elements.temperatureToggle.checked = false;
+      elements.humidityToggle.checked = false;
+      enableRange(
+        elements.temperatureToggle,
+        [elements.tempMinInput, elements.tempMaxInput],
+        [elements.tempMinSlider, elements.tempMaxSlider],
+        [60, 80]
+      );
+      enableRange(
+        elements.humidityToggle,
+        [elements.humidityMinInput, elements.humidityMaxInput],
+        [elements.humidityMinSlider, elements.humidityMaxSlider],
+        [20, 70]
+      );
+      elements.submitButton.textContent = "Save Task";
+      elements.cancelEditButton.hidden = true;
+      Object.keys(elements.formErrors).forEach((field) => setFieldError(field, ""));
+      if (state.lastZip) {
+        elements.zipInput.value = state.lastZip;
+      }
+    };
+
+    const populateForm = (task) => {
+      elements.nameInput.value = task.name;
+      elements.durationInput.value = task.durationHours;
+      elements.zipInput.value = task.location;
+      elements.earliestInput.value = task.earliestStart || "";
+      elements.latestInput.value = task.latestStart || "";
+      elements.noRainToggle.checked = !!task.requireDry;
+      elements.temperatureToggle.checked = !!task.temperatureEnabled;
+      elements.humidityToggle.checked = !!task.humidityEnabled;
+      enableRange(
+        elements.temperatureToggle,
+        [elements.tempMinInput, elements.tempMaxInput],
+        [elements.tempMinSlider, elements.tempMaxSlider],
+        [task.minTemp ?? 60, task.maxTemp ?? 80]
+      );
+      enableRange(
+        elements.humidityToggle,
+        [elements.humidityMinInput, elements.humidityMaxInput],
+        [elements.humidityMinSlider, elements.humidityMaxSlider],
+        [task.minHumidity ?? 20, task.maxHumidity ?? 70]
+      );
+      if (task.temperatureEnabled) {
+        elements.tempMinInput.value = task.minTemp;
+        elements.tempMaxInput.value = task.maxTemp;
+        elements.tempMinSlider.value = task.minTemp;
+        elements.tempMaxSlider.value = task.maxTemp;
+      }
+      if (task.humidityEnabled) {
+        elements.humidityMinInput.value = task.minHumidity;
+        elements.humidityMaxInput.value = task.maxHumidity;
+        elements.humidityMinSlider.value = task.minHumidity;
+        elements.humidityMaxSlider.value = task.maxHumidity;
+      }
+      elements.submitButton.textContent = "Update Task";
+      elements.cancelEditButton.hidden = false;
+    };
+
+    const applySuggestion = (task, suggestion) => {
+      if (suggestion === "widen-temp") {
+        if (!task.temperatureEnabled) {
+          task.temperatureEnabled = true;
+          task.minTemp = 60;
+          task.maxTemp = 80;
+        } else {
+          task.minTemp = Math.max(task.minTemp - 5, -20);
+          task.maxTemp = Math.min(task.maxTemp + 5, 120);
+        }
+      }
+      if (suggestion === "allow-rain") {
+        task.requireDry = false;
+      }
+      analytics("suggestion_applied", { taskId: task.id, suggestion });
+      const newWindows = generateWindowsForTask(task);
+      task.windows = newWindows;
+      if (newWindows.length) {
+        task.scheduledWindow = { start: newWindows[0].start, end: newWindows[0].end };
+        if (task.status !== "Completed") {
+          task.status = "Scheduled";
+        }
+      } else {
+        task.scheduledWindow = null;
+        task.status = "Pending";
+      }
+      saveTasks();
+      renderTaskList();
+    };
+    const createTaskFromValues = (values, existing = null) => {
+      const id = existing?.id || `task-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+      const task = {
+        id,
+        name: values.name.trim(),
+        durationHours: values.duration,
+        location: values.zip,
+        earliestStart: values.earliest || "",
+        latestStart: values.latest || "",
+        temperatureEnabled: values.temperatureEnabled,
+        minTemp: values.temperatureEnabled ? values.minTemp : null,
+        maxTemp: values.temperatureEnabled ? values.maxTemp : null,
+        humidityEnabled: values.humidityEnabled,
+        minHumidity: values.humidityEnabled ? values.minHumidity : null,
+        maxHumidity: values.humidityEnabled ? values.maxHumidity : null,
+        requireDry: values.requireDry,
+        status: existing?.status || "Scheduled",
+        createdAt: existing?.createdAt || new Date().toISOString(),
+        windowsCollapsed: existing?.windowsCollapsed || false
+      };
+      const generated = generateWindowsForTask(task);
+      task.windows = generated;
+      if (generated.length) {
+        task.scheduledWindow = existing?.scheduledWindow || {
+          start: generated[0].start,
+          end: generated[0].end
+        };
+        task.status = existing?.status || "Scheduled";
+      } else {
+        task.scheduledWindow = null;
+        task.status = "Pending";
+      }
+      return task;
+    };
+
+    const handleFormSubmit = (event) => {
+      event.preventDefault();
+      const values = collectFormValues();
+      const errors = validateValues(values);
+      displayErrors(errors);
+      const firstErrorKey = Object.entries(errors).find(([, value]) => value)?.[0];
+      if (firstErrorKey) {
+        analytics("task_submit_validation_error", { field: firstErrorKey });
+        const focusTarget = {
+          name: elements.nameInput,
+          duration: elements.durationInput,
+          zip: elements.zipInput,
+          time: elements.earliestInput,
+          temperature: elements.tempMinInput,
+          humidity: elements.humidityMinInput
+        }[firstErrorKey];
+        if (focusTarget) focusTarget.focus();
+        return;
+      }
+
+      const existingTask = state.tasks.find((task) => task.id === state.editingTaskId) || null;
+      const newTask = createTaskFromValues(values, existingTask);
+      if (existingTask) {
+        state.tasks = state.tasks.map((task) => (task.id === existingTask.id ? newTask : task));
+      } else {
+        state.tasks = [newTask, ...state.tasks];
+      }
+      state.lastZip = values.zip;
+      localStorage.setItem(STORAGE_KEYS.lastZip, state.lastZip);
+      saveTasks();
+      renderTaskList();
+      analytics("task_submit_success", { taskId: newTask.id, edited: Boolean(existingTask) });
+      showToast("Task added. Finding best weather windows.");
+      if (state.layoutMode === "mobile") {
+        closeModal();
+      }
+      resetForm();
+      elements.nameInput.focus();
+    };
+
+    const openModal = (source = "button") => {
+      analytics("task_form_opened", { source });
+      if (state.layoutMode === "mobile") {
+        state.modalOpen = true;
+        elements.addPanel.classList.add("is-modal", "is-open");
+        elements.modalOverlay.hidden = false;
+        state.previousFocus = document.activeElement;
+        const focusable = elements.addPanel.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const trap = (event) => {
+          if (event.key !== "Tab") return;
+          if (focusable.length === 0) return;
+          if (event.shiftKey) {
+            if (document.activeElement === first) {
+              event.preventDefault();
+              last.focus();
+            }
+          } else if (document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        };
+        state.trapHandler = trap;
+        elements.addPanel.addEventListener("keydown", trap);
+        document.body.style.overflow = "hidden";
+        if (first) first.focus();
+      } else if (state.layoutMode === "tablet") {
+        setTabletCollapsed(false);
+        elements.nameInput.focus();
+      } else {
+        elements.nameInput.focus();
+      }
+    };
+
+    const closeModal = ({ restoreFocus = true } = {}) => {
+      if (state.trapHandler) {
+        elements.addPanel.removeEventListener("keydown", state.trapHandler);
+        state.trapHandler = null;
+      }
+      if (state.layoutMode === "mobile") {
+        elements.addPanel.classList.add("is-modal");
+      }
+      elements.addPanel.classList.remove("is-open");
+      elements.modalOverlay.hidden = true;
+      document.body.style.overflow = "";
+      if (restoreFocus && state.previousFocus && typeof state.previousFocus.focus === "function") {
+        state.previousFocus.focus();
+      }
+      state.previousFocus = null;
+      state.modalOpen = false;
+    };
+
+    const setTabletCollapsed = (collapsed) => {
+      state.addCollapsed = collapsed;
+      if (collapsed) {
+        elements.addPanel.classList.add("is-collapsed");
+        elements.tabletToggle.setAttribute("aria-expanded", "false");
+        elements.tabletToggle.querySelector(".tablet-toggle-label").textContent = "Expand";
+      } else {
+        elements.addPanel.classList.remove("is-collapsed");
+        elements.tabletToggle.setAttribute("aria-expanded", "true");
+        elements.tabletToggle.querySelector(".tablet-toggle-label").textContent = "Collapse";
+      }
+    };
+
+    const applyLayoutMode = () => {
+      const width = window.innerWidth;
+      let nextMode = "desktop";
+      if (width < 768) {
+        nextMode = "mobile";
+      } else if (width >= 768 && width < 1024) {
+        nextMode = "tablet";
+      }
+      if (nextMode === state.layoutMode) return;
+      state.layoutMode = nextMode;
+      const main = document.getElementById("appMain");
+      if (nextMode === "desktop") {
+        if (main.firstElementChild !== elements.addPanel) {
+          main.insertBefore(elements.addPanel, elements.taskListPanel);
+        }
+        closeModal({ restoreFocus: false });
+        elements.addPanel.classList.remove("is-modal", "is-open");
+        elements.modalOverlay.hidden = true;
+        setTabletCollapsed(false);
+      } else if (nextMode === "tablet") {
+        if (main.firstElementChild === elements.addPanel) {
+          main.insertBefore(elements.taskListPanel, elements.addPanel);
+        }
+        closeModal({ restoreFocus: false });
+        elements.addPanel.classList.remove("is-modal", "is-open");
+        elements.modalOverlay.hidden = true;
+        setTabletCollapsed(false);
+      } else {
+        if (main.firstElementChild === elements.addPanel) {
+          main.insertBefore(elements.taskListPanel, elements.addPanel);
+        }
+        elements.addPanel.classList.add("is-modal");
+        closeModal({ restoreFocus: false });
+      }
+    };
+
+    const refreshTaskWindows = (task, scope = "single", button = null) => {
+      if (button) {
+        button.classList.add("refreshing");
+        button.disabled = true;
+      }
+      setTimeout(() => {
+        const refreshed = generateWindowsForTask(task);
+        task.windows = refreshed;
+        if (refreshed.length) {
+          task.scheduledWindow = { start: refreshed[0].start, end: refreshed[0].end };
+          if (task.status !== "Completed") {
+            task.status = "Scheduled";
+          }
+        } else {
+          task.scheduledWindow = null;
+          task.status = "Pending";
+        }
+        analytics("windows_refreshed", { taskId: task.id, scope });
+        saveTasks();
+        renderTaskList();
+        if (button) {
+          button.classList.remove("refreshing");
+          button.disabled = false;
+        }
+      }, 600);
+    };
+    loadStoredTasks();
+    applyLayoutMode();
+    updateAdvancedVisibility();
+    resetForm();
+    renderTaskList();
+
+    if (!state.lastZip && navigator.geolocation) {
+      elements.zipInput.placeholder = "Detecting location…";
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const approxZip = nearestZip(position.coords.latitude, position.coords.longitude);
+          if (approxZip) {
+            elements.zipInput.value = approxZip;
+            state.lastZip = approxZip;
+            localStorage.setItem(STORAGE_KEYS.lastZip, approxZip);
+          } else {
+            elements.zipInput.placeholder = "Enter 5-digit ZIP";
+          }
+        },
+        () => {
+          elements.zipInput.placeholder = "Enter 5-digit ZIP";
+        },
+        { enableHighAccuracy: false, timeout: 4000 }
+      );
+    } else if (state.lastZip) {
+      elements.zipInput.value = state.lastZip;
+    }
+
+    window.addEventListener("resize", () => applyLayoutMode());
+
+    elements.tabletToggle.addEventListener("click", () => {
+      setTabletCollapsed(!state.addCollapsed);
+    });
+
+    elements.floatingButton.addEventListener("click", () => {
+      openModal("floating_button");
+    });
+
+    elements.modalCloseButton.addEventListener("click", () => {
+      closeModal();
+    });
+
+    elements.modalOverlay.addEventListener("click", () => {
+      closeModal();
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && state.layoutMode === "mobile" && state.modalOpen) {
+        closeModal();
+      }
+    });
+
+    elements.advancedToggle.addEventListener("click", () => {
+      state.advancedOpen = !state.advancedOpen;
+      persistAdvancedState();
+      updateAdvancedVisibility();
+    });
+
+    elements.temperatureToggle.addEventListener("change", () => {
+      enableRange(
+        elements.temperatureToggle,
+        [elements.tempMinInput, elements.tempMaxInput],
+        [elements.tempMinSlider, elements.tempMaxSlider],
+        [60, 80]
+      );
+      displayErrors(validateValues(collectFormValues()));
+    });
+
+    elements.humidityToggle.addEventListener("change", () => {
+      enableRange(
+        elements.humidityToggle,
+        [elements.humidityMinInput, elements.humidityMaxInput],
+        [elements.humidityMinSlider, elements.humidityMaxSlider],
+        [20, 70]
+      );
+      displayErrors(validateValues(collectFormValues()));
+    });
+
+    const bindRangeSync = (minInput, maxInput, minSlider, maxSlider, minBound, maxBound) => {
+      minSlider.addEventListener("input", () => {
+        const minVal = Number(minSlider.value);
+        if (minVal > Number(maxSlider.value)) {
+          maxSlider.value = minVal;
+        }
+        minInput.value = minSlider.value;
+        maxInput.value = maxSlider.value;
+        displayErrors(validateValues(collectFormValues()));
+      });
+      maxSlider.addEventListener("input", () => {
+        const maxVal = Number(maxSlider.value);
+        if (maxVal < Number(minSlider.value)) {
+          minSlider.value = maxVal;
+        }
+        minInput.value = minSlider.value;
+        maxInput.value = maxSlider.value;
+        displayErrors(validateValues(collectFormValues()));
+      });
+      [minInput, maxInput].forEach((input) => {
+        input.addEventListener("input", () => {
+          input.value = input.value.replace(/[^0-9-]/g, "");
+          syncSliders(minInput, maxInput, minSlider, maxSlider, minBound, maxBound);
+          displayErrors(validateValues(collectFormValues()));
+        });
+      });
+    };
+
+    bindRangeSync(
+      elements.tempMinInput,
+      elements.tempMaxInput,
+      elements.tempMinSlider,
+      elements.tempMaxSlider,
+      -20,
+      120
+    );
+    bindRangeSync(
+      elements.humidityMinInput,
+      elements.humidityMaxInput,
+      elements.humidityMinSlider,
+      elements.humidityMaxSlider,
+      0,
+      100
+    );
+
+    elements.durationSteppers.forEach((button) => {
+      button.addEventListener("click", () => {
+        const current = Number(elements.durationInput.value) || 0;
+        const step = Number(button.dataset.step);
+        let next = Math.round((current + step) * 4) / 4;
+        next = Math.min(Math.max(next, 0.25), 24);
+        elements.durationInput.value = next.toFixed(2).replace(/\.00$/, "").replace(/\.25$/, ".25").replace(/\.5$/, ".5");
+        displayErrors(validateValues(collectFormValues()));
+      });
+    });
+
+    elements.durationInput.addEventListener("input", () => {
+      elements.durationInput.value = elements.durationInput.value.replace(/[^0-9.]/g, "");
+      displayErrors(validateValues(collectFormValues()));
+    });
+
+    elements.zipInput.addEventListener("input", () => {
+      elements.zipInput.value = elements.zipInput.value.replace(/\D/g, "").slice(0, 5);
+      displayErrors(validateValues(collectFormValues()));
+    });
+
+    [elements.nameInput, elements.earliestInput, elements.latestInput].forEach((input) => {
+      input.addEventListener("input", () => {
+        displayErrors(validateValues(collectFormValues()));
+      });
+    });
+
+    elements.noRainToggle.addEventListener("change", () => {
+      displayErrors(validateValues(collectFormValues()));
+    });
+
+    elements.presetChips.forEach((chip) => {
+      chip.addEventListener("click", () => {
+        const preset = chip.dataset.preset;
+        analytics("preset_used", { preset });
+        state.advancedOpen = true;
+        updateAdvancedVisibility();
+        persistAdvancedState();
+        if (preset === "warm") {
+          elements.temperatureToggle.checked = true;
+          enableRange(
+            elements.temperatureToggle,
+            [elements.tempMinInput, elements.tempMaxInput],
+            [elements.tempMinSlider, elements.tempMaxSlider],
+            [70, 85]
+          );
+          elements.tempMinInput.value = 70;
+          elements.tempMaxInput.value = 85;
+          elements.tempMinSlider.value = 70;
+          elements.tempMaxSlider.value = 85;
+        }
+        if (preset === "cool") {
+          elements.temperatureToggle.checked = true;
+          enableRange(
+            elements.temperatureToggle,
+            [elements.tempMinInput, elements.tempMaxInput],
+            [elements.tempMinSlider, elements.tempMaxSlider],
+            [50, 65]
+          );
+          elements.tempMinInput.value = 50;
+          elements.tempMaxInput.value = 65;
+          elements.tempMinSlider.value = 50;
+          elements.tempMaxSlider.value = 65;
+        }
+        if (preset === "dry") {
+          elements.noRainToggle.checked = true;
+        }
+        displayErrors(validateValues(collectFormValues()));
+      });
+    });
+
+    elements.cancelEditButton.addEventListener("click", () => {
+      resetForm();
+      if (state.layoutMode === "mobile") {
+        closeModal();
+      }
+    });
+
+    elements.form.addEventListener("submit", handleFormSubmit);
+
+    elements.taskList.addEventListener("click", (event) => {
+      const targetButton = event.target.closest("button[data-action]");
+      if (!targetButton) return;
+      const card = targetButton.closest(".task-card");
+      if (!card) return;
+      const taskId = card.dataset.taskId;
+      const task = state.tasks.find((item) => item.id === taskId);
+      if (!task) return;
+
+      const action = targetButton.dataset.action;
+      if (action === "edit-task") {
+        state.editingTaskId = task.id;
+        populateForm(task);
+        if (state.layoutMode === "mobile") {
+          openModal("edit");
+        } else if (state.layoutMode === "tablet" && state.addCollapsed) {
+          setTabletCollapsed(false);
+        }
+        elements.nameInput.focus();
+      }
+
+      if (action === "delete-task") {
+        state.tasks = state.tasks.filter((item) => item.id !== task.id);
+        if (state.editingTaskId === task.id) {
+          resetForm();
+        }
+        saveTasks();
+        renderTaskList();
+      }
+
+      if (action === "toggle-complete") {
+        if (task.status === "Completed") {
+          task.status = task.scheduledWindow ? "Scheduled" : "Pending";
+        } else {
+          task.status = "Completed";
+        }
+        saveTasks();
+        renderTaskList();
+      }
+
+      if (action === "refresh-task") {
+        refreshTaskWindows(task, "single", targetButton);
+      }
+
+      if (action === "schedule-window") {
+        const index = Number(targetButton.dataset.windowIndex);
+        const windows = state.conflictMap.get(task.id) || [];
+        const selected = windows[index];
+        if (selected) {
+          task.scheduledWindow = { start: selected.start, end: selected.end };
+          task.status = "Scheduled";
+          analytics("task_rescheduled_via_alt_window", { taskId: task.id });
+          saveTasks();
+          renderTaskList();
+        }
+      }
+
+      if (action === "toggle-windows") {
+        task.windowsCollapsed = !task.windowsCollapsed;
+        saveTasks();
+        renderTaskList();
+      }
+
+      if (action === "apply-suggestion") {
+        const suggestion = targetButton.dataset.suggestion;
+        applySuggestion(task, suggestion);
+      }
+    });
+
+    elements.refreshAllButton.addEventListener("click", () => {
+      const button = elements.refreshAllButton;
+      button.classList.add("refreshing");
+      button.disabled = true;
+      state.tasks.forEach((task) => {
+        refreshTaskWindows(task, "all");
+      });
+      setTimeout(() => {
+        button.classList.remove("refreshing");
+        button.disabled = false;
+      }, 900);
+    });
+  });
+})();

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,51 +1,988 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS (and SCSS, if configured) file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
- */
-
-body {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  margin: 2rem;
-  background-color: #f5f6f8;
-  color: #222;
+:root {
+  --accent: #2563eb;
+  --text: #101828;
+  --muted: #667085;
+  --surface: #ffffff;
+  --border: #e5e7eb;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --bg-soft: #f5f7fb;
+  --shadow-soft: 0 12px 32px rgba(15, 23, 42, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --transition-fast: 150ms ease;
+  --transition-medium: 220ms ease;
 }
 
-.hero {
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body.app-body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.12), transparent 55%),
+    radial-gradient(circle at top right, rgba(16, 185, 129, 0.12), transparent 45%),
+    var(--bg-soft);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+p {
+  margin: 0;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.app-shell {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1.75rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(16, 185, 129, 0.08));
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  gap: 1rem;
+}
+
+.app-brand {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.app-mark {
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  background: rgba(37, 99, 235, 0.14);
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+}
+
+.app-supertitle {
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  margin-bottom: 0.3rem;
+}
+
+.app-title {
+  font-size: clamp(1.4rem, 2vw + 1rem, 2.4rem);
+  font-weight: 700;
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.task-list-panel,
+.add-task-panel {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  padding: 1.75rem;
+  position: relative;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel-kicker {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.4rem;
+}
+
+.panel-title {
+  font-size: 1.45rem;
+}
+
+.panel-subtitle {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-bottom: 1.25rem;
+}
+
+.panel-header-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.text-button,
+.icon-button,
+.primary-button,
+.chip,
+.floating-add-button,
+.stepper,
+.suggestion-button {
+  border: none;
+  background: none;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border-radius: var(--radius-sm);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
+}
+
+.text-button {
+  padding: 0.4rem 0.75rem;
+  color: var(--accent);
+  font-weight: 600;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.text-button:hover,
+.text-button:focus-visible {
+  background: rgba(37, 99, 235, 0.16);
+}
+
+.icon-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(16, 24, 40, 0.08);
+}
+
+.icon-button svg,
+.text-button svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  background: rgba(16, 24, 40, 0.14);
+}
+
+.primary-button {
+  background: var(--accent);
+  color: #fff;
+  padding: 0.85rem 1.5rem;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.22);
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  background: #1d4ed8;
+}
+
+.primary-button:disabled {
+  background: rgba(37, 99, 235, 0.4);
+  box-shadow: none;
+}
+
+.task-list-empty {
+  padding: 1.75rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--muted);
+  margin-bottom: 0.75rem;
+}
+
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.task-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
   padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
   background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.1);
-  margin-bottom: 2rem;
 }
 
-.hero h1 {
-  margin-top: 0;
+.task-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
-section {
-  margin-bottom: 1.75rem;
+.task-card__title {
+  font-size: 1.2rem;
+  font-weight: 600;
 }
 
-code {
-  background: rgba(15, 23, 42, 0.08);
-  padding: 0.1rem 0.3rem;
-  border-radius: 4px;
+.status-pill {
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
 }
 
-pre {
-  background: rgba(15, 23, 42, 0.08);
-  padding: 0.75rem;
+.status-pill svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+.status-pill[data-status="pending"] {
+  background: rgba(245, 158, 11, 0.16);
+  color: var(--warning);
+}
+
+.status-pill[data-status="completed"] {
+  background: rgba(16, 185, 129, 0.16);
+  color: var(--success);
+}
+
+.task-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.task-card__meta svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.12);
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.task-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.task-card__actions .text-button {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text);
+}
+
+.task-card__actions .text-button:hover,
+.task-card__actions .text-button:focus-visible {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.possible-windows {
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.possible-windows header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.window-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.window-row {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.window-row[data-conflict="true"] {
+  border-color: var(--warning);
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.window-row[data-preferred="true"] {
+  border-color: var(--success);
+  background: rgba(16, 185, 129, 0.12);
+}
+
+.window-row .window-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.window-row .window-meta span:first-child {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.window-row .window-meta span:last-child {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.window-row .row-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.window-row .row-actions .text-button {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+}
+
+.window-icons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--warning);
+}
+
+.window-icons[data-status="clear"] {
+  color: var(--success);
+}
+
+.window-icons svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.task-card__empty {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  padding: 1.25rem;
+  background: rgba(37, 99, 235, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--muted);
+}
+
+.suggestion-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.suggestion-button {
+  padding: 0.45rem 0.9rem;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.suggestion-button:hover,
+.suggestion-button:focus-visible {
+  background: rgba(37, 99, 235, 0.2);
+}
+
+.add-task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.form-section-kicker {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  margin-bottom: 0.35rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem 1.25rem;
+}
+
+.form-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.form-control label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.form-control .muted {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.field-hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.field-error {
+  color: var(--danger);
+  font-size: 0.85rem;
+  min-height: 1rem;
+}
+
+.field-error:empty {
+  display: none;
+}
+
+input[type="text"],
+input[type="number"],
+input[type="time"],
+input[type="range"],
+input[type="search"] {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  padding: 0.65rem 0.75rem;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+input[type="range"] {
+  padding: 0;
+}
+
+input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+  outline: none;
+}
+
+.input-with-buttons {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.input-with-buttons input {
+  border: none;
+  text-align: center;
+  min-width: 80px;
+  padding: 0.65rem 0.5rem;
+}
+
+.input-with-buttons input:focus-visible {
+  box-shadow: none;
+}
+
+.stepper {
+  width: 40px;
+  height: 40px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: transparent;
+}
+
+.stepper:hover,
+.stepper:focus-visible {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.3);
+  transition: background var(--transition-fast);
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch-slider {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform var(--transition-fast), background var(--transition-fast);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.25);
+}
+
+.switch input:checked + .switch-slider {
+  transform: translateX(20px);
+  background: var(--accent);
+}
+
+.switch input:checked ~ span,
+.switch input:checked ~ .switch-slider {
+  background: var(--accent);
+}
+
+.range-group {
+  gap: 0.75rem;
+}
+
+.range-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.range-row {
+  display: grid;
+  grid-template-columns: minmax(80px, 1fr) auto minmax(80px, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.range-row input {
+  width: 100%;
+}
+
+.slider-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.slider-row input {
+  -webkit-appearance: none;
+  appearance: none;
+  background: rgba(15, 23, 42, 0.1);
+  height: 6px;
   border-radius: 8px;
-  overflow-x: auto;
+}
+
+.slider-row input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+}
+
+.slider-row input::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+}
+
+.toggle-row,
+.range-group {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.toggle-header,
+.range-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.toggle-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.preset-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  padding: 0.4rem 0.85rem;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.chip:hover,
+.chip:focus-visible {
+  background: rgba(37, 99, 235, 0.16);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+#cancelEditButton {
+  color: var(--muted);
+  background: rgba(148, 163, 184, 0.16);
+}
+
+#cancelEditButton:hover,
+#cancelEditButton:focus-visible {
+  background: rgba(148, 163, 184, 0.24);
+}
+
+.tablet-toggle,
+.modal-close {
+  display: none;
+}
+
+.floating-add-button {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-size: 2rem;
+  box-shadow: 0 20px 35px rgba(37, 99, 235, 0.35);
+  display: none;
+  z-index: 30;
+}
+
+.floating-add-button:hover,
+.floating-add-button:focus-visible {
+  background: #1d4ed8;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  z-index: 20;
+}
+
+.modal-overlay[hidden] {
+  display: none;
+}
+
+.add-task-panel.is-modal {
+  position: fixed;
+  inset: 0;
+  margin: 0;
+  max-width: none;
+  border-radius: 0;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  overflow-y: auto;
+  transform: translateY(100%);
+  transition: transform var(--transition-medium);
+}
+
+.add-task-panel.is-collapsed .panel-subtitle,
+.add-task-panel.is-collapsed .add-task-form {
+  display: none;
+}
+
+.add-task-panel.is-collapsed .tablet-toggle-label::after {
+  content: "";
+}
+
+.add-task-panel.is-collapsed .tablet-toggle svg {
+  transform: rotate(180deg);
+}
+
+.add-task-panel.is-modal.is-open {
+  transform: translateY(0);
+}
+
+.add-task-panel.is-modal .panel-subtitle {
+  margin-bottom: 1.5rem;
+}
+
+.toast-region {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 60;
+  align-items: center;
+}
+
+.toast {
+  background: #fff;
+  color: var(--text);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1.2rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  font-weight: 600;
+}
+
+.toast[data-type="success"] {
+  border-color: rgba(16, 185, 129, 0.4);
+}
+
+.toast[data-type="error"] {
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 600px) {
+  .app-shell {
+    padding: 2rem 2rem 3.5rem;
+  }
+
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .form-grid > :last-child {
+    grid-column: span 2;
+  }
+}
+
+@media (min-width: 768px) {
+  .app-main {
+    gap: 1.75rem;
+  }
+
+  .add-task-panel,
+  .task-list-panel {
+    padding: 2rem;
+  }
+
+  .tablet-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (min-width: 1024px) {
+  .app-main {
+    display: grid;
+    grid-template-columns: 0.9fr 1.2fr;
+    gap: 1.75rem;
+    align-items: start;
+  }
+
+  .tablet-toggle {
+    display: none;
+  }
+
+  .form-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .form-grid > :nth-child(1) {
+    grid-column: span 3;
+  }
+
+  .form-grid > :nth-child(2),
+  .form-grid > :nth-child(3) {
+    grid-column: span 1;
+  }
+
+  .task-list {
+    max-height: none;
+  }
+}
+
+@media (max-width: 1023px) {
+  .task-card__actions {
+    width: 100%;
+  }
+}
+
+@media (max-width: 900px) {
+  .task-card__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .task-card__actions .text-button {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 767px) {
+  .app-shell {
+    padding-bottom: 6rem;
+  }
+
+  .app-header {
+    padding: 1.5rem;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-grid > * {
+    grid-column: span 1;
+  }
+
+  .floating-add-button {
+    display: inline-flex;
+  }
+
+  .add-task-panel:not(.is-modal) {
+    display: none;
+  }
+
+  .modal-close {
+    display: inline-flex;
+  }
+
+  .tablet-toggle {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}
+
+[hidden] {
+  display: none !important;
+}
+
+button:focus-visible,
+.text-button:focus-visible,
+.icon-button:focus-visible,
+.primary-button:focus-visible,
+.chip:focus-visible,
+.suggestion-button:focus-visible,
+.floating-add-button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+}
+
+.refreshing::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(37, 99, 235, 0.3);
+  border-top-color: var(--accent);
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,32 +1,220 @@
-<div class="hero">
-  <h1>Weather-Aware Task Scheduler</h1>
-  <p class="lead">
-    Use the JSON API endpoints to create tasks that respect temperature, humidity, and rainfall constraints.
-  </p>
+<div class="app-shell" data-app-shell>
+  <header class="app-header">
+    <div class="app-brand">
+      <div class="app-mark" aria-hidden="true">☀️</div>
+      <div>
+        <p class="app-supertitle">Weather Task Scheduler</p>
+        <h1 class="app-title">Plan every task around the perfect forecast</h1>
+      </div>
+    </div>
+    <button type="button" class="icon-button" id="settingsButton" aria-label="Settings">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M10.325 4.317a1 1 0 0 1 1.35-.447l.1.058 1.2.8a1 1 0 0 0 .567.154h1.4a1 1 0 0 1 .993.883L16 5.9v1.2a1 1 0 0 0 .154.567l.8 1.2a1 1 0 0 1 .058 1.094l-.058.1-1 1.5a1 1 0 0 0-.154.567v1.4a1 1 0 0 1-.883.993L14.7 14.6h-1.2a1 1 0 0 0-.567.154l-1.2.8a1 1 0 0 1-1.094.058l-.1-.058-1.5-1a1 1 0 0 0-.567-.154H7.2a1 1 0 0 1-.993-.883L6.2 13.4v-1.2a1 1 0 0 0-.154-.567l-.8-1.2a1 1 0 0 1-.058-1.094l.058-.1 1-1.5a1 1 0 0 0 .154-.567V6.2a1 1 0 0 1 .883-.993L7.3 5.2h1.2a1 1 0 0 0 .567-.154l1.2-.8ZM12 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z" />
+      </svg>
+    </button>
+  </header>
+
+  <main class="app-main" id="appMain" data-app-main>
+    <section class="task-list-panel" id="taskListPanel" aria-labelledby="taskListHeading">
+      <div class="panel-header">
+        <div>
+          <p class="panel-kicker">Scheduled Tasks</p>
+          <h2 class="panel-title" id="taskListHeading">Task List</h2>
+        </div>
+        <button type="button" class="text-button" id="refreshAllButton" data-action="refresh-all">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M4 4v5h.008l.002.116A1 1 0 0 0 5 10h5a1 1 0 0 0 0-2H7.618a5 5 0 1 1-.633 4.33 1 1 0 1 0-1.952.444A7 7 0 1 0 12 5H9a1 1 0 0 0-.993.883L8 6v.117L7.993 7H9a1 1 0 0 0 0-2Z" />
+          </svg>
+          Refresh all windows
+        </button>
+      </div>
+      <p class="panel-subtitle">Review upcoming tasks, conflicts, and alternative windows at a glance.</p>
+      <div class="task-list-empty" id="taskListEmpty" role="status" hidden>
+        <p>No tasks yet. Add your first task to see weather-aware windows.</p>
+      </div>
+      <div class="task-list" id="taskList" data-task-list></div>
+    </section>
+
+    <aside class="add-task-panel" id="addTaskPanel" aria-labelledby="addTaskHeading">
+      <div class="panel-header add-task-header">
+        <div>
+          <p class="panel-kicker">Add a Task</p>
+          <h2 class="panel-title" id="addTaskHeading">Add Task</h2>
+        </div>
+        <div class="panel-header-actions">
+          <button type="button" class="text-button tablet-toggle" id="tabletToggleButton" aria-expanded="true" aria-controls="addTaskForm">
+            <span class="tablet-toggle-label">Collapse</span>
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M7.757 8.343a1 1 0 0 1 1.32-.083l.094.083L12 11.172l2.829-2.829a1 1 0 0 1 1.497 1.32l-.083.094-3.536 3.536a1 1 0 0 1-1.32.083l-.094-.083-3.536-3.536a1 1 0 0 1 0-1.414Z" />
+            </svg>
+          </button>
+          <button type="button" class="icon-button modal-close" id="modalCloseButton" aria-label="Close add task panel">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M6.225 4.811a1 1 0 0 1 1.32-.083l.094.083L12 9.172l4.36-4.36a1 1 0 0 1 1.497 1.32l-.083.094L13.828 10.5l4.36 4.36a1 1 0 0 1-.083 1.497l-.094.083a1 1 0 0 1-1.32.083l-.094-.083L12 12.828l-4.36 4.36a1 1 0 0 1-1.497-1.32l.083-.094L10.172 10.5l-4.36-4.36a1 1 0 0 1 0-1.414Z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <p class="panel-subtitle">Group essentials, set windows, and fine-tune weather preferences.</p>
+      <form id="addTaskForm" class="add-task-form" novalidate>
+        <section class="form-section" aria-labelledby="sectionBasicsHeading">
+          <header class="form-section-header">
+            <div>
+              <p class="form-section-kicker">Section A</p>
+              <h3 id="sectionBasicsHeading">Basics</h3>
+            </div>
+          </header>
+          <div class="form-grid">
+            <div class="form-control" data-field="name">
+              <label for="taskName">Task Name<span aria-hidden="true">*</span></label>
+              <input id="taskName" name="name" type="text" autocomplete="off" required minlength="2" maxlength="80" placeholder="e.g., Paint the deck" aria-describedby="nameHint nameError">
+              <p class="field-hint" id="nameHint">Provide a descriptive name between 2 and 80 characters.</p>
+              <p class="field-error" id="nameError" role="alert"></p>
+            </div>
+            <div class="form-control" data-field="duration">
+              <label for="taskDuration">Duration (hours)<span aria-hidden="true">*</span></label>
+              <div class="input-with-buttons">
+                <button type="button" class="stepper" data-step="-0.25" aria-label="Decrease duration">−</button>
+                <input id="taskDuration" name="duration" type="number" min="0.25" max="24" step="0.25" value="1" required aria-describedby="durationError">
+                <button type="button" class="stepper" data-step="0.25" aria-label="Increase duration">+</button>
+              </div>
+              <p class="field-error" id="durationError" role="alert"></p>
+            </div>
+            <div class="form-control" data-field="zip">
+              <label for="taskZip">Location ZIP<span aria-hidden="true">*</span></label>
+              <input id="taskZip" name="zip" type="text" inputmode="numeric" pattern="\d{5}" maxlength="5" placeholder="e.g., 98101" aria-describedby="zipHint zipError">
+              <p class="field-hint" id="zipHint">We’ll use the ZIP to look up precise hourly forecasts.</p>
+              <p class="field-error" id="zipError" role="alert"></p>
+            </div>
+          </div>
+        </section>
+
+        <section class="form-section" aria-labelledby="sectionTimeHeading">
+          <header class="form-section-header">
+            <div>
+              <p class="form-section-kicker">Section B</p>
+              <h3 id="sectionTimeHeading">Time Window</h3>
+            </div>
+          </header>
+          <div class="form-grid">
+            <div class="form-control" data-field="earliest">
+              <label for="taskEarliest">Earliest Start <span class="muted">(daily)</span></label>
+              <input id="taskEarliest" name="earliest" type="time" aria-describedby="earliestHint timeError">
+              <p class="field-hint" id="earliestHint">Earliest Start (daily)</p>
+            </div>
+            <div class="form-control" data-field="latest">
+              <label for="taskLatest">Latest Start <span class="muted">(daily)</span></label>
+              <input id="taskLatest" name="latest" type="time" aria-describedby="latestHint timeError">
+              <p class="field-hint" id="latestHint">Latest Start (daily)</p>
+            </div>
+          </div>
+          <p class="field-error" id="timeError" role="alert"></p>
+        </section>
+
+        <section class="form-section advanced" aria-labelledby="sectionAdvancedHeading">
+          <header class="form-section-header advanced-header">
+            <div>
+              <p class="form-section-kicker">Section C</p>
+              <h3 id="sectionAdvancedHeading">Advanced Filters</h3>
+            </div>
+            <button type="button" class="text-button" id="advancedToggle" aria-expanded="false" aria-controls="advancedContent">
+              <span class="advanced-toggle-label">Show advanced</span>
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M12 14.5a1 1 0 0 1-.707-.293l-4-4a1 1 0 0 1 1.414-1.414L12 12.086l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4A1 1 0 0 1 12 14.5Z" />
+              </svg>
+            </button>
+          </header>
+          <div class="advanced-content" id="advancedContent" hidden>
+            <div class="preset-chips" role="group" aria-label="Presets">
+              <button type="button" class="chip" data-preset="warm">Warm Day</button>
+              <button type="button" class="chip" data-preset="cool">Cool Day</button>
+              <button type="button" class="chip" data-preset="dry">Dry Only</button>
+            </div>
+
+            <div class="form-control toggle-row">
+              <div class="toggle-header">
+                <div>
+                  <span class="toggle-title">Require Rain-free</span>
+                  <p class="field-hint">Only schedule when no precipitation is forecast.</p>
+                </div>
+                <label class="switch">
+                  <input type="checkbox" id="taskNoRain" name="no_rain">
+                  <span class="switch-slider" aria-hidden="true"></span>
+                </label>
+              </div>
+            </div>
+
+            <div class="form-control range-group" data-field="temperature">
+              <div class="range-header">
+                <div>
+                  <span class="toggle-title">Temperature Range</span>
+                  <p class="field-hint">Set preferred temperatures in °F.</p>
+                </div>
+                <label class="switch">
+                  <input type="checkbox" id="temperatureToggle" name="temperature_enabled">
+                  <span class="switch-slider" aria-hidden="true"></span>
+                </label>
+              </div>
+              <div class="range-inputs" data-range="temperature" aria-describedby="temperatureError">
+                <div class="range-row">
+                  <label for="tempMin" class="sr-only">Minimum temperature</label>
+                  <input id="tempMin" name="temp_min" type="number" inputmode="numeric" step="1" min="-20" max="120" disabled>
+                  <span class="unit">°F</span>
+                  <label for="tempMax" class="sr-only">Maximum temperature</label>
+                  <input id="tempMax" name="temp_max" type="number" inputmode="numeric" step="1" min="-20" max="120" disabled>
+                  <span class="unit">°F</span>
+                </div>
+                <div class="slider-row">
+                  <input type="range" id="tempMinSlider" min="-20" max="120" step="1" value="60" disabled>
+                  <input type="range" id="tempMaxSlider" min="-20" max="120" step="1" value="80" disabled>
+                </div>
+              </div>
+              <p class="field-error" id="temperatureError" role="alert"></p>
+            </div>
+
+            <div class="form-control range-group" data-field="humidity">
+              <div class="range-header">
+                <div>
+                  <span class="toggle-title">Humidity Range</span>
+                  <p class="field-hint">Humidity: 0% dry, 100% very humid.</p>
+                </div>
+                <label class="switch">
+                  <input type="checkbox" id="humidityToggle" name="humidity_enabled">
+                  <span class="switch-slider" aria-hidden="true"></span>
+                </label>
+              </div>
+              <div class="range-inputs" data-range="humidity" aria-describedby="humidityError">
+                <div class="range-row">
+                  <label for="humidityMin" class="sr-only">Minimum humidity</label>
+                  <input id="humidityMin" name="humidity_min" type="number" inputmode="numeric" step="1" min="0" max="100" disabled>
+                  <span class="unit">%</span>
+                  <label for="humidityMax" class="sr-only">Maximum humidity</label>
+                  <input id="humidityMax" name="humidity_max" type="number" inputmode="numeric" step="1" min="0" max="100" disabled>
+                  <span class="unit">%</span>
+                </div>
+                <div class="slider-row">
+                  <input type="range" id="humidityMinSlider" min="0" max="100" step="1" value="20" disabled>
+                  <input type="range" id="humidityMaxSlider" min="0" max="100" step="1" value="70" disabled>
+                </div>
+              </div>
+              <p class="field-error" id="humidityError" role="alert"></p>
+            </div>
+          </div>
+        </section>
+
+        <div class="form-actions">
+          <button type="submit" class="primary-button" id="submitTaskButton">Save Task</button>
+          <button type="button" class="text-button" id="cancelEditButton">Cancel edit</button>
+        </div>
+      </form>
+    </aside>
+  </main>
+
+  <button type="button" class="floating-add-button" id="floatingAddButton" aria-haspopup="dialog">
+    <span aria-hidden="true">＋</span>
+    <span class="sr-only">Add Task</span>
+  </button>
 </div>
 
-<section>
-  <h2>Available Endpoints</h2>
-  <ul>
-    <li><code>GET /tasks</code> – List all scheduled tasks.</li>
-    <li><code>POST /tasks</code> – Create a task and receive scheduling suggestions.</li>
-    <li><code>GET /tasks/:id</code> – Retrieve a single task.</li>
-    <li><code>PUT /tasks/:id</code> – Update a task and recompute weather windows.</li>
-    <li><code>DELETE /tasks/:id</code> – Remove a task.</li>
-    <li><code>POST /suggestions</code> – Request updated windows for an existing task.</li>
-  </ul>
-</section>
-
-<section>
-  <h2>Environment Setup</h2>
-  <p>
-    Set the <code>OPENWEATHER_API_KEY</code> environment variable before starting the server or running tests.
-  </p>
-  <pre><code>export OPENWEATHER_API_KEY="your-openweather-api-key"
-bin/rails server</code></pre>
-</section>
-
-<section>
-  <h2>Data Overview</h2>
-  <p>There are currently <strong><%= @tasks_count %></strong> task(s) stored.</p>
-</section>
+<div class="modal-overlay" id="modalOverlay" hidden></div>
+<div class="toast-region" id="toastRegion" role="status" aria-live="polite"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>WeatherTaskScheduler</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "application" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 
-  <body>
+  <body class="app-body">
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the mobile modal cleanup runs regardless of layout changes so resizing releases focus traps and scroll locking
- hide the tablet-only collapse toggle on desktop widths to avoid redundant controls

## Testing
- `bin/rails test` *(fails: missing locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68cb590814fc8320a4cfb671d93e20ad